### PR TITLE
feat: import.meta.glob을 활용한 자동 파일 라우팅 적용 Closes #10

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export interface FileRouterPluginOptions {
 
 export interface Server {
   watcher: {
-    add: (file: string) => void;
-    on: (event: string, callback: (file: string) => void) => void;
+    add: (fileOrDir: string) => void;
+    on: (event: "add" | "unlink", callback: (filePath: string) => void) => void;
   };
 }


### PR DESCRIPTION
- 기존 fs 기반 라우팅 로직을 import.meta.glob으로 대체하여 성능 최적화
- pages 디렉터리의 모든 .tsx 파일을 자동으로 스캔하여 라우팅 구성
- NotFound 및 Loading 컴포넌트를 플러그인 옵션으로 주입할 수 있도록 개선
- RouterConfig.tsx를 플러그인이 자동 생성하도록 구현